### PR TITLE
Use multistage build to copy into distroless image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,15 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 #
-FROM openzipkin/zipkin:2.12.5
-MAINTAINER OpenZipkin "http://zipkin.io/"
+
+FROM alpine
+
+WORKDIR /zipkin-aws
 
 ENV ZIPKIN_AWS_REPO https://jcenter.bintray.com
 ENV ZIPKIN_AWS_VERSION 0.16.1
 
-RUN apk add unzip && \ 
+RUN apk add curl unzip && \
   curl -SL $ZIPKIN_AWS_REPO/io/zipkin/aws/zipkin-autoconfigure-collector-sqs/$ZIPKIN_AWS_VERSION/zipkin-autoconfigure-collector-sqs-$ZIPKIN_AWS_VERSION-module.jar > sqs.jar && \
   curl -SL $ZIPKIN_AWS_REPO/io/zipkin/aws/zipkin-autoconfigure-collector-kinesis/$ZIPKIN_AWS_VERSION/zipkin-autoconfigure-collector-kinesis-$ZIPKIN_AWS_VERSION-module.jar > kinesis.jar && \
   curl -SL $ZIPKIN_AWS_REPO/io/zipkin/aws/zipkin-autoconfigure-storage-elasticsearch-aws/$ZIPKIN_AWS_VERSION/zipkin-autoconfigure-storage-elasticsearch-aws-$ZIPKIN_AWS_VERSION-module.jar > elasticsearch-aws.jar && \
@@ -30,7 +32,11 @@ RUN apk add unzip && \
   rm sqs.jar && \
   rm kinesis.jar && \
   rm elasticsearch-aws.jar && \
-  rm xray.jar && \
-  apk del unzip
+  rm xray.jar
 
-CMD test -n "$STORAGE_TYPE" && source .${STORAGE_TYPE}_profile; java ${JAVA_OPTS} -Dloader.path=sqs,kinesis,elasticsearch-aws,xray -Dspring.profiles.active=sqs,kinesis,elasticsearch-aws,xray -cp . org.springframework.boot.loader.PropertiesLauncher
+FROM openzipkin/zipkin:2.12.5
+MAINTAINER OpenZipkin "http://zipkin.io/"
+
+COPY --from=0 /zipkin-aws/ /zipkin/
+
+ENV JAVA_OPTS="-Dloader.path=sqs,kinesis,elasticsearch-aws,xray -Dspring.profiles.active=sqs,kinesis,elasticsearch-aws,xray ${JAVA_OPTS}"


### PR DESCRIPTION
The idea is that now that the runtime image doesn't contain an OS distribution, including package manager, we always want to use a multi-stage build to get a folder set up with what we need in one image that uses alpine or debian, and then copy into the runtime image using `COPY --from=`.

Fixes #8