### PR TITLE
Switches from JAVA_OPTS to MODULE_OPTS for profile settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ MAINTAINER OpenZipkin "http://zipkin.io/"
 
 COPY --from=0 /zipkin-aws/ /zipkin/
 
-ENV JAVA_OPTS="-Dloader.path=sqs,kinesis,elasticsearch-aws,xray -Dspring.profiles.active=sqs,kinesis,elasticsearch-aws,xray ${JAVA_OPTS}"
+ENV MODULE_OPTS="-Dloader.path=sqs,kinesis,elasticsearch-aws,xray -Dspring.profiles.active=sqs,kinesis,elasticsearch-aws,xray"


### PR DESCRIPTION
This avoids clobbering aws profile info when someone sets JAVA_OPTS

See https://github.com/openzipkin/docker-zipkin/pull/202