### PR TITLE
Use the latest zipking release (2.14.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN apk add curl unzip && \
   rm elasticsearch-aws.jar && \
   rm xray.jar
 
-FROM openzipkin/zipkin:2.13.0
+FROM openzipkin/zipkin:2.14.0
 MAINTAINER Zipkin "http://zipkin.apache.org/"
 
 COPY --from=0 /zipkin-aws/ /zipkin/


### PR DESCRIPTION
Hi,

I would love to see the latest zipkin improvements in your aws-specific image.
Upgrading it in the Dockerfile to help get the thing going.

Thanks in advance,
Joseph
